### PR TITLE
Added a server parameter to the writer

### DIFF
--- a/papertrail.go
+++ b/papertrail.go
@@ -35,12 +35,13 @@ const (
 type Writer struct {
 	Port    int
 	Network string
+	Server  string
 }
 
 func (w *Writer) Write(p []byte) (n int, err error) {
 
 	var conn net.Conn
-	address := fmt.Sprintf("logs.papertrailapp.com:%d", w.Port)
+	address := fmt.Sprintf("%s.papertrailapp.com:%d", w.Server, w.Port)
 
 	switch w.Network {
 	case UDP:

--- a/papertrail.go
+++ b/papertrail.go
@@ -41,6 +41,11 @@ type Writer struct {
 func (w *Writer) Write(p []byte) (n int, err error) {
 
 	var conn net.Conn
+
+	if w.Server == "" {
+		w.Server = "logs"
+	}
+
 	address := fmt.Sprintf("%s.papertrailapp.com:%d", w.Server, w.Port)
 
 	switch w.Network {


### PR DESCRIPTION
For my papertrail setup, I have to send logs to `logs2.papertrailapp.com` but there was no way to do that.  This adds the field to the `Writer` struct and uses it to construct the address.
